### PR TITLE
Check if Repository is nil to avoid a panic

### DIFF
--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"path"
@@ -34,6 +35,12 @@ func CloneBare(URL string) (Repository, error) {
 // https://kernel.org/pub/software/scm/git/docs/gitrevisions.html. Returns an
 // open io.ReadCloser, file size, and error.
 func (r *Repository) FileOpenAtRev(filePath string, rev plumbing.Revision) (io.ReadCloser, int64, error) {
+	// Check if Repository is nil to avoid a panic if this function is called
+	// before repo has been cloned
+	if r.Repository == nil {
+		return nil, 0, errors.New("Repository is nil")
+	}
+
 	ref, err := r.ResolveRevision(rev)
 	if err != nil {
 		return nil, 0, fmt.Errorf("Revision resolve of %s: %s", ref, err)
@@ -50,6 +57,12 @@ func (r *Repository) FileOpenAtRef(filePath string, ref plumbing.Reference) (io.
 // fileOpenAtHash opens a file at a given path at a given hash. Returns an open io.ReadCloser,
 // file size, and error.
 func (r *Repository) fileOpenAtHash(filePath string, hash plumbing.Hash) (io.ReadCloser, int64, error) {
+	// Check if Repository is nil to avoid a panic if this function is called
+	// before repo has been cloned
+	if r.Repository == nil {
+		return nil, 0, errors.New("Repository is nil")
+	}
+
 	commit, err := r.CommitObject(hash)
 	if err != nil {
 		return nil, 0, fmt.Errorf("Commit object of %v: %s", hash, err)
@@ -85,6 +98,12 @@ func (r *Repository) fileOpenAtHash(filePath string, hash plumbing.Hash) (io.Rea
 // tag that meets the supplied contraint. Silently ignores tags that aren't
 // parsable as a semantic version.
 func (r *Repository) FindSemverTag(c *semver.Constraints) (*plumbing.Reference, error) {
+	// Check if Repository is nil to avoid a panic if this function is called
+	// before repo has been cloned
+	if r.Repository == nil {
+		return nil, errors.New("Repository is nil")
+	}
+
 	tagsIter, err := r.Tags()
 	if err != nil {
 		return nil, err

--- a/pkg/repository/repository_test.go
+++ b/pkg/repository/repository_test.go
@@ -56,42 +56,56 @@ func TestRepository_FileOpenAtRev(t *testing.T) {
 	}
 	tests := []struct {
 		name    string
+		repo    Repository
 		args    args
 		want    []byte
 		wantErr bool
 	}{
 		{
+			name:    "Empty repository struct",
+			repo:    Repository{},
+			args:    args{},
+			want:    nil,
+			wantErr: true,
+		},
+		{
 			name:    "Reference not found",
+			repo:    r,
 			args:    args{filePath: "CHANGELOG", rev: plumbing.Revision("asdf1234")},
 			want:    nil,
 			wantErr: true,
 		},
 		{
 			name:    "Open and read CHANGELOG at refs/heads/master",
+			repo:    r,
 			args:    args{filePath: "CHANGELOG", rev: plumbing.Revision("refs/heads/master")},
 			want:    []byte("Initial changelog\n"),
 			wantErr: false,
 		},
 		{
 			name:    "Open and read CHANGELOG at refs/remotes/origin/branch",
+			repo:    r,
 			args:    args{filePath: "CHANGELOG", rev: plumbing.Revision("refs/remotes/origin/branch")},
 			want:    []byte("Initial changelog\n"),
 			wantErr: false,
 		},
 		{
 			name: "Open and read vendor/foo.go at refs/heads/master",
+			repo: r,
 			args: args{filePath: "vendor/foo.go", rev: plumbing.Revision("refs/heads/master")},
 			want: []byte("package main\n\nimport \"fmt\"\n\nfunc main() {\n	fmt.Println(\"Hello, playground\")\n}\n"),
 			wantErr: false,
 		},
 		{
 			name:    "Open and read CHANGELOG at 6ecf0ef2c2dffb796033e5a02219af86ec6584e5",
+			repo:    r,
 			args:    args{filePath: "CHANGELOG", rev: plumbing.Revision("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")},
 			want:    []byte("Initial changelog\n"),
 			wantErr: false,
 		},
 		{
 			name:    "Open and read CHANGELOG at short ref master",
+			repo:    r,
 			args:    args{filePath: "CHANGELOG", rev: plumbing.Revision("master")},
 			want:    []byte("Initial changelog\n"),
 			wantErr: false,
@@ -99,7 +113,7 @@ func TestRepository_FileOpenAtRev(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, _, err := r.FileOpenAtRev(tt.args.filePath, tt.args.rev)
+			got, _, err := tt.repo.FileOpenAtRev(tt.args.filePath, tt.args.rev)
 
 			if err != nil {
 				if !tt.wantErr {
@@ -137,36 +151,49 @@ func TestRepository_fileOpenAtHash(t *testing.T) {
 	}
 	tests := []struct {
 		name    string
+		repo    Repository
 		args    args
 		want    []byte
 		wantErr bool
 	}{
 		{
+			name:    "Empty repository struct",
+			repo:    Repository{},
+			args:    args{},
+			want:    nil,
+			wantErr: true,
+		},
+		{
 			name:    "Non-existent commit hash",
+			repo:    r,
 			args:    args{filePath: "CHANGELOG", hash: plumbing.NewHash("0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f")},
 			want:    nil,
 			wantErr: true,
 		},
 		{
 			name:    "Non-existent file path",
+			repo:    r,
 			args:    args{filePath: "asdf/ghjk", hash: plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")},
 			want:    nil,
 			wantErr: true,
 		},
 		{
 			name:    "Open and read CHANGELOG at 6ecf0ef2c2dffb796033e5a02219af86ec6584e5",
+			repo:    r,
 			args:    args{filePath: "CHANGELOG", hash: plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")},
 			want:    []byte("Initial changelog\n"),
 			wantErr: false,
 		},
 		{
 			name:    "Open and read CHANGELOG at a remote branch commit e8d3ffab552895c19b9fcf7aa264d277cde33881",
+			repo:    r,
 			args:    args{filePath: "CHANGELOG", hash: plumbing.NewHash("e8d3ffab552895c19b9fcf7aa264d277cde33881")},
 			want:    []byte("Initial changelog\n"),
 			wantErr: false,
 		},
 		{
 			name: "Open and read vendor/foo.go at 6ecf0ef2c2dffb796033e5a02219af86ec6584e5",
+			repo: r,
 			args: args{filePath: "vendor/foo.go", hash: plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")},
 			want: []byte("package main\n\nimport \"fmt\"\n\nfunc main() {\n	fmt.Println(\"Hello, playground\")\n}\n"),
 			wantErr: false,
@@ -174,7 +201,7 @@ func TestRepository_fileOpenAtHash(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, _, err := r.fileOpenAtHash(tt.args.filePath, tt.args.hash)
+			got, _, err := tt.repo.fileOpenAtHash(tt.args.filePath, tt.args.hash)
 			if err != nil {
 				if !tt.wantErr {
 					t.Errorf("Repository.fileOpenAtHash() error = %v, wantErr %v", err, tt.wantErr)
@@ -215,42 +242,54 @@ func TestRepository_FindSemverTag(t *testing.T) {
 
 	tests := []struct {
 		name       string
+		repo       Repository
 		constraint *semver.Constraints
 		wantHash   plumbing.Hash
 		wantErr    bool
 	}{
 		{
+			name:    "Empty repository struct",
+			repo:    Repository{},
+			wantErr: true,
+		},
+		{
 			name:       "0.0.1",
+			repo:       r,
 			constraint: zeroZeroOne,
 			wantHash:   plumbing.NewHash("bdbfd0ebc52195e74f4d748bed9adde12a275c75"),
 			wantErr:    false,
 		},
 		{
 			name:       "~0.0.1",
+			repo:       r,
 			constraint: zeroZeroOnePatch,
 			wantHash:   plumbing.NewHash("f9beb3bc5e04eb1a33f85805e1f2c5541e6661fc"),
 			wantErr:    false,
 		},
 		{
 			name:       "~0.1",
+			repo:       r,
 			constraint: zeroOnePatch,
 			wantHash:   plumbing.NewHash("48e8f899ab1cf3a3be36371f4161cfb897659c45"),
 			wantErr:    false,
 		},
 		{
 			name:       "~1.0.0",
+			repo:       r,
 			constraint: oneZeroZeroPatch,
 			wantHash:   plumbing.NewHash("c204415aafecf7dd22513f3d7158d224a32763f4"),
 			wantErr:    false,
 		},
 		{
 			name:       "~1.0.0-0",
+			repo:       r,
 			constraint: oneZeroOnePrePatch,
 			wantHash:   plumbing.NewHash("774270d020ae8e17836bc399f238b77cda990e77"),
 			wantErr:    false,
 		},
 		{
 			name:       "~9.9.9 non-existant version",
+			repo:       r,
 			constraint: nineNineNinePatch,
 			wantHash:   plumbing.Hash{},
 			wantErr:    true,
@@ -258,7 +297,7 @@ func TestRepository_FindSemverTag(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := r.FindSemverTag(tt.constraint)
+			got, err := tt.repo.FindSemverTag(tt.constraint)
 			if err != nil {
 				if !tt.wantErr {
 					t.Errorf("Repository.FindSemverTag() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
Any repository.Repository method that can call a git.Repository method with a nil (eg. not yet cloned) git.Repository Repository struct attribute, needs to check if it is nil. Otherwise a panic will happen due to a nil pointer dereference.